### PR TITLE
Update `dep` to use my fork of vault

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,7 +39,8 @@
 
 [[constraint]]
   name = "github.com/hashicorp/vault"
-  branch = "master"
+  source = "github.com/krish7919/vault"
+  revision = "ac52e397fa732786600f02c139e64b87169cb368"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
- update `Gopkg.toml` manually to specify a `source` constraint for the
`github.com/hashicorp/vault` dependency. This modification tells `dep` to
`git clone` from my fork.

- the `revision` constraint tells `dep` to `git checkout` my lastest
changes.